### PR TITLE
fix: derive package version from metadata

### DIFF
--- a/qworld/__init__.py
+++ b/qworld/__init__.py
@@ -11,4 +11,10 @@ Usage:
 from .client import CriteriaGenerator
 
 __all__ = ["CriteriaGenerator"]
-__version__ = "0.1.1"
+
+try:
+    from importlib.metadata import PackageNotFoundError, version
+
+    __version__ = version("qworld")
+except PackageNotFoundError:
+    __version__ = "0.1.2"


### PR DESCRIPTION
## Summary
- derive qworld.__version__ from installed package metadata
- keep a source-tree fallback aligned with pyproject.toml

## Validation
- python -m compileall qworld
- python -c "import qworld; assert qworld.__version__ == '0.1.2', qworld.__version__; print(qworld.__version__)"
- git diff --check
