### PR TITLE
fix: normalize CLI input shapes

### DIFF
--- a/qworld/__main__.py
+++ b/qworld/__main__.py
@@ -11,6 +11,32 @@ import json
 import os
 
 
+def normalize_input_data(data):
+    """Normalize CLI JSON input to the list shape expected by batch generation."""
+    if isinstance(data, str):
+        return [{"id": "0", "question": data}]
+
+    if isinstance(data, dict):
+        item = data.copy()
+        item.setdefault("id", "0")
+        return [item]
+
+    if isinstance(data, list):
+        items = []
+        for idx, item in enumerate(data):
+            if isinstance(item, str):
+                items.append({"id": str(idx), "question": item})
+            elif isinstance(item, dict):
+                normalized = item.copy()
+                normalized.setdefault("id", str(idx))
+                items.append(normalized)
+            else:
+                raise ValueError("Input list items must be strings or objects")
+        return items
+
+    raise ValueError("Input JSON must be a string, object, or list")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate evaluation criteria for questions")
     parser.add_argument("-i", "--input", type=str, required=True, help="Input JSON file")
@@ -30,7 +56,7 @@ def main():
     
     # Load input
     with open(args.input, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+        data = normalize_input_data(json.load(f))
     
     if args.max_examples:
         data = data[:args.max_examples]

--- a/tests/test_cli_input_normalization.py
+++ b/tests/test_cli_input_normalization.py
@@ -1,0 +1,36 @@
+import unittest
+
+from qworld.__main__ import normalize_input_data
+
+
+class CliInputNormalizationTest(unittest.TestCase):
+    def test_string_input_becomes_single_question_item(self):
+        self.assertEqual(
+            normalize_input_data("What is AI?"),
+            [{"id": "0", "question": "What is AI?"}],
+        )
+
+    def test_dict_input_gets_default_id_without_mutation(self):
+        data = {"question": "What is AI?"}
+
+        result = normalize_input_data(data)
+
+        self.assertEqual(result, [{"id": "0", "question": "What is AI?"}])
+        self.assertEqual(data, {"question": "What is AI?"})
+
+    def test_list_input_accepts_strings_and_dicts(self):
+        self.assertEqual(
+            normalize_input_data(["What is AI?", {"id": "custom", "question": "What is ML?"}]),
+            [
+                {"id": "0", "question": "What is AI?"},
+                {"id": "custom", "question": "What is ML?"},
+            ],
+        )
+
+    def test_invalid_list_item_raises_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "strings or objects"):
+            normalize_input_data([42])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize CLI JSON input before batch generation
- support the same string, object, and list input shapes documented for the Python API
- add regression tests for CLI input normalization and invalid list items

## Validation
- python -m unittest discover -s tests -v
- python -m compileall qworld tests
- git diff --check
