### PR TITLE
fix: normalize CLI and client input shapes

### DIFF
--- a/qworld/__main__.py
+++ b/qworld/__main__.py
@@ -11,6 +11,16 @@ import json
 import os
 
 
+def _normalize_input_data(data):
+    if isinstance(data, str):
+        return [{"id": "0", "question": data}]
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return data
+    raise TypeError("input JSON must be a string, object, or array")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate evaluation criteria for questions")
     parser.add_argument("-i", "--input", type=str, required=True, help="Input JSON file")
@@ -30,7 +40,7 @@ def main():
     
     # Load input
     with open(args.input, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+        data = _normalize_input_data(json.load(f))
     
     if args.max_examples:
         data = data[:args.max_examples]
@@ -64,6 +74,8 @@ def main():
     )
     
     results = gen.generate(data)
+    if isinstance(results, dict):
+        results = [results]
     all_results = existing + results
     
     os.makedirs(os.path.dirname(args.output) or '.', exist_ok=True)

--- a/qworld/client.py
+++ b/qworld/client.py
@@ -16,6 +16,31 @@ from .prompts import get_prompt
 from .schemas import AGENT_SCHEMAS
 
 
+def normalize_questions(
+    questions: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]]
+) -> tuple[bool, List[Dict[str, Any]]]:
+    """Normalize generate() input without mutating caller-owned objects."""
+    if isinstance(questions, str):
+        return True, [{"id": "0", "question": questions}]
+
+    if isinstance(questions, dict):
+        item = questions.copy()
+        item.setdefault("id", "0")
+        return True, [item]
+
+    items = []
+    for i, q in enumerate(questions):
+        if isinstance(q, str):
+            items.append({"id": str(i), "question": q})
+        elif isinstance(q, dict):
+            item = q.copy()
+            item.setdefault("id", str(i))
+            items.append(item)
+        else:
+            raise TypeError("questions must be a string, dict, or list of strings/dicts")
+    return False, items
+
+
 class CriteriaGenerator:
     """
     Generate evaluation criteria for questions using LLMs.
@@ -472,25 +497,7 @@ class CriteriaGenerator:
                 {"id": "q2", "question": "How does ML work?"},
             ])
         """
-        # Normalize input
-        single_input = False
-        if isinstance(questions, str):
-            single_input = True
-            items = [{"id": "0", "question": questions}]
-        elif isinstance(questions, dict):
-            single_input = True
-            if "id" not in questions:
-                questions["id"] = "0"
-            items = [questions]
-        else:
-            items = []
-            for i, q in enumerate(questions):
-                if isinstance(q, str):
-                    items.append({"id": str(i), "question": q})
-                else:
-                    if "id" not in q:
-                        q["id"] = str(i)
-                    items.append(q)
+        single_input, items = normalize_questions(questions)
         
         # Process single item
         def process_one(item, use_parallel=False, verbose=False):

--- a/tests/test_cli_input_normalization.py
+++ b/tests/test_cli_input_normalization.py
@@ -1,0 +1,47 @@
+import json
+import sys
+
+import pytest
+
+import qworld.__main__ as cli
+import qworld.client as client
+
+
+def test_normalize_input_data_accepts_supported_shapes():
+    assert cli._normalize_input_data("What is AI?") == [{"id": "0", "question": "What is AI?"}]
+
+    item = {"question": "What is AI?"}
+    assert cli._normalize_input_data(item) == [item]
+
+    items = [{"question": "A"}, {"question": "B"}]
+    assert cli._normalize_input_data(items) is items
+
+
+def test_normalize_input_data_rejects_unsupported_json():
+    with pytest.raises(TypeError, match="input JSON"):
+        cli._normalize_input_data(42)
+
+
+def test_main_handles_single_object_input(tmp_path, monkeypatch):
+    input_path = tmp_path / "input.json"
+    output_path = tmp_path / "output.json"
+    input_path.write_text(json.dumps({"id": "q1", "question": "What is AI?"}), encoding="utf-8")
+
+    class FakeGenerator:
+        def __init__(self, **kwargs):
+            pass
+
+        def generate(self, data):
+            assert data == [{"id": "q1", "question": "What is AI?"}]
+            return [{"id": "q1", "final_criteria": []}]
+
+    monkeypatch.setattr(client, "CriteriaGenerator", FakeGenerator)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["qworld", "-i", str(input_path), "-o", str(output_path), "--max-examples", "1"],
+    )
+
+    cli.main()
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == [{"id": "q1", "final_criteria": []}]

--- a/tests/test_client_input_normalization.py
+++ b/tests/test_client_input_normalization.py
@@ -1,0 +1,52 @@
+import qworld.client as client
+from qworld.client import CriteriaGenerator, normalize_questions
+
+
+def _generator_without_clients(monkeypatch):
+    gen = CriteriaGenerator.__new__(CriteriaGenerator)
+    gen.n_scenario_expands = 0
+    gen.n_perspective_expands = 0
+    gen.n_criteria_expands = 0
+    gen.dedup_threshold = 0.6
+    gen.max_workers = 2
+    gen._log_fn = None
+    gen._call_llm = lambda *args, **kwargs: None
+    gen._get_embeddings = lambda texts: []
+
+    def fake_pipeline(item, **kwargs):
+        return {
+            "prompt_id": item.get("prompt_id", item.get("id")),
+            "question": item.get("question"),
+        }
+
+    monkeypatch.setattr(client, "run_pipeline", fake_pipeline)
+    return gen
+
+
+def test_normalize_questions_does_not_mutate_single_dict():
+    question = {"question": "What is AI?"}
+
+    single_input, items = normalize_questions(question)
+
+    assert single_input is True
+    assert items == [{"id": "0", "question": "What is AI?"}]
+    assert question == {"question": "What is AI?"}
+
+
+def test_generate_does_not_mutate_batch_dicts(monkeypatch):
+    gen = _generator_without_clients(monkeypatch)
+    questions = [{"question": "A"}, {"id": "custom", "question": "B"}]
+
+    results = gen.generate(questions)
+
+    assert questions == [{"question": "A"}, {"id": "custom", "question": "B"}]
+    assert {r["id"] for r in results} == {"0", "custom"}
+
+
+def test_generate_single_string_returns_single_result(monkeypatch):
+    gen = _generator_without_clients(monkeypatch)
+
+    result = gen.generate("What is AI?")
+
+    assert result["id"] == "0"
+    assert result["question"] == "What is AI?"


### PR DESCRIPTION
Summary
- normalize CLI JSON input so string/object/list inputs are handled consistently
- normalize CriteriaGenerator.generate inputs without mutating caller-owned dictionaries
- add regression tests for client and CLI input shapes

Validation
- python -m pytest -q tests/test_client_input_normalization.py tests/test_cli_input_normalization.py
- python -m compileall -q qworld