### PR TITLE
[codex] add Qworld CLI JSONL batch IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ results = gen.generate([
 }
 ```
 
+### CLI JSONL Batches
+
+The `qworld` command accepts either JSON arrays or newline-delimited JSON. JSONL
+is useful for large batches because each line is one independent question:
+
+```bash
+qworld -i questions.jsonl -o criteria.jsonl --input-format jsonl --output-format jsonl
+```
+
+When `--input-format` is omitted, `.jsonl` files are detected automatically.
+
 ---
 
 ## Supported Models

--- a/qworld/__main__.py
+++ b/qworld/__main__.py
@@ -11,11 +11,42 @@ import json
 import os
 
 
+def _load_input(path, input_format="auto"):
+    """Load JSON or JSONL input for CLI batch generation."""
+    if input_format == "auto":
+        input_format = "jsonl" if path.endswith(".jsonl") else "json"
+
+    with open(path, "r", encoding="utf-8") as f:
+        if input_format == "jsonl":
+            return [json.loads(line) for line in f if line.strip()]
+        if input_format == "json":
+            return json.load(f)
+
+    raise ValueError(f"Unsupported input format: {input_format}")
+
+
+def _write_output(path, results, output_format="json"):
+    """Write CLI results as JSON or JSONL."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        if output_format == "jsonl":
+            for result in results:
+                f.write(json.dumps(result, ensure_ascii=False) + "\n")
+            return
+        if output_format == "json":
+            json.dump(results, f, ensure_ascii=False, indent=2)
+            return
+
+    raise ValueError(f"Unsupported output format: {output_format}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate evaluation criteria for questions")
     parser.add_argument("-i", "--input", type=str, required=True, help="Input JSON file")
     parser.add_argument("-o", "--output", type=str, required=True, help="Output JSON file")
     parser.add_argument("-m", "--model", type=str, default="gpt-4o", help="Model name")
+    parser.add_argument("--input-format", choices=["auto", "json", "jsonl"], default="auto")
+    parser.add_argument("--output-format", choices=["json", "jsonl"], default="json")
     parser.add_argument("--base-url", type=str, help="API base URL (for vLLM)")
     parser.add_argument("--api-key", type=str, help="API key (uses env vars if not set)")
     parser.add_argument("--temperature", type=float, default=0.4)
@@ -28,9 +59,7 @@ def main():
     
     args = parser.parse_args()
     
-    # Load input
-    with open(args.input, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+    data = _load_input(args.input, args.input_format)
     
     if args.max_examples:
         data = data[:args.max_examples]
@@ -38,8 +67,7 @@ def main():
     # Resume: filter already processed
     existing = []
     if args.resume and os.path.exists(args.output):
-        with open(args.output, 'r', encoding='utf-8') as f:
-            existing = json.load(f)
+        existing = _load_input(args.output, args.output_format)
         done_ids = {r.get("id") or r.get("prompt_id") for r in existing if "final_criteria" in r}
         data = [d for d in data if (d.get("id") or d.get("prompt_id")) not in done_ids]
         print(f"Resuming: {len(existing)} done, {len(data)} remaining")
@@ -66,9 +94,7 @@ def main():
     results = gen.generate(data)
     all_results = existing + results
     
-    os.makedirs(os.path.dirname(args.output) or '.', exist_ok=True)
-    with open(args.output, 'w', encoding='utf-8') as f:
-        json.dump(all_results, f, ensure_ascii=False, indent=2)
+    _write_output(args.output, all_results, args.output_format)
     
     success = sum(1 for r in results if 'error' not in r)
     print(f"Done: {success}/{len(results)} successful. Saved to {args.output}")

--- a/tests/test_cli_io.py
+++ b/tests/test_cli_io.py
@@ -1,0 +1,43 @@
+import json
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "qworld_cli", Path(__file__).resolve().parents[1] / "qworld" / "__main__.py"
+)
+qworld_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(qworld_cli)
+
+_load_input = qworld_cli._load_input
+_write_output = qworld_cli._write_output
+
+
+def test_load_jsonl_input(tmp_path):
+    path = tmp_path / "questions.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": "q1", "question": "What is AI?"}),
+                json.dumps({"id": "q2", "question": "What is ML?"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert _load_input(str(path)) == [
+        {"id": "q1", "question": "What is AI?"},
+        {"id": "q2", "question": "What is ML?"},
+    ]
+
+
+def test_write_jsonl_output(tmp_path):
+    path = tmp_path / "results.jsonl"
+    _write_output(
+        str(path),
+        [{"id": "q1", "final_criteria": []}, {"id": "q2", "final_criteria": []}],
+        output_format="jsonl",
+    )
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["id"] for line in lines] == ["q1", "q2"]


### PR DESCRIPTION
## Summary
- Add JSONL input/output support to the Qworld CLI.
- Document JSONL batch usage in the README.
- Add dependency-light tests for JSONL load/write helpers.

## Validation
- `python -m pytest Qworld\tests\test_cli_io.py -q`
